### PR TITLE
Deprecate accessible-autocomplete-multiselect

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 0

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Accessible autocomplete multi select
+# Accessible autocomplete multi select (DEPRECATED)
+
+> **NOTE**: This project is deprecated and is [planned to be retired](https://trello.com/c/zLNLSKok/85-design-accessible-replacement-for-accessible-autocomplete-multiselect).
+
+---
 
 The accessible autocomplete is a component that helps users choose answers from a list you provide. You can also use it to make the answers you get from users more consistent.
 


### PR DESCRIPTION
As done in https://github.com/alphagov/content-publisher/pull/3287 and https://github.com/alphagov/maslow/pull/1293, we want to disable Dependabot PRs for this deprecated repo.